### PR TITLE
Adjusting the TaskRunner API examples after OpenFL breaking changes

### DIFF
--- a/openfl_contrib_workspace/keras_nlp/plan/plan.yaml
+++ b/openfl_contrib_workspace/keras_nlp/plan/plan.yaml
@@ -15,7 +15,7 @@ collaborator :
   template : openfl.component.Collaborator
   settings :
     db_store_rounds: 2
-    delta_updates    : false
+    use_delta_updates    : false
     opt_treatment    : RESET
 
 data_loader :

--- a/openfl_contrib_workspace/torch/unet_kvasir/plan/plan.yaml
+++ b/openfl_contrib_workspace/torch/unet_kvasir/plan/plan.yaml
@@ -14,7 +14,7 @@ collaborator :
   defaults : plan/defaults/collaborator.yaml
   template : openfl.component.Collaborator
   settings :
-    delta_updates    : false
+    use_delta_updates    : false
     opt_treatment    : RESET
 
 data_loader :

--- a/openfl_contrib_workspace/torch_cnn_mnist_custom_weighted_average/plan/plan.yaml
+++ b/openfl_contrib_workspace/torch_cnn_mnist_custom_weighted_average/plan/plan.yaml
@@ -14,7 +14,7 @@ collaborator :
   defaults : plan/defaults/collaborator.yaml
   template : openfl.component.Collaborator
   settings :
-    delta_updates    : false
+    use_delta_updates    : false
     opt_treatment    : RESET
 
 data_loader :

--- a/openfl_contrib_workspace/torch_cnn_mnist_skc_compression/plan/plan.yaml
+++ b/openfl_contrib_workspace/torch_cnn_mnist_skc_compression/plan/plan.yaml
@@ -15,7 +15,7 @@ collaborator :
   defaults : plan/defaults/collaborator.yaml
   template : openfl.component.Collaborator
   settings :
-    delta_updates    : false
+    use_delta_updates    : false
     opt_treatment    : RESET
 
 data_loader :


### PR DESCRIPTION
These changes are needed following the merge of https://github.com/securefederatedai/openfl/pull/1422 in OpenFL.